### PR TITLE
Only allow creation of original 150 pokemon

### DIFF
--- a/app/forms/pokemons/create_pokemon_form.rb
+++ b/app/forms/pokemons/create_pokemon_form.rb
@@ -4,6 +4,10 @@ class Pokemons::CreatePokemonForm
   attr_accessor :name, :kind
 
   validates :name, :kind, presence: true
+  validates :name, inclusion: { 
+    in: OriginalPokemon::NAMES, 
+    message: "must be one of the original 150 pokemon" 
+  }
 
   def save
     return false if invalid?
@@ -11,4 +15,5 @@ class Pokemons::CreatePokemonForm
     pokemon = Pokemon.new(name: name, kind: kind)
     pokemon.save!
   end
+
 end

--- a/app/models/original_pokemon.rb
+++ b/app/models/original_pokemon.rb
@@ -1,0 +1,27 @@
+class OriginalPokemon
+  NAMES = [
+      "Bulbasaur","Ivysaur","Venusaur","Charmander","Charmeleon","Charizard",
+      "Squirtle","Wartortle","Blastoise","Caterpie","Metapod","Butterfree",
+      "Weedle","Kakuna","Beedrill","Pidgey","Pidgeotto","Pidgeot","Rattata",
+      "Raticate","Spearow","Fearow","Ekans","Arbok","Pikachu","Raichu",
+      "Sandshrew","Sandslash","Nidoran","Nidorina","Nidoqueen","Nidoran",
+      "Nidorino","Nidoking","Clefairy","Clefable","Vulpix","Ninetales",
+      "Jigglypuff","Wigglytuff","Zubat","Golbat","Oddish","Gloom","Vileplume",
+      "Paras","Parasect","Venonat","Venomoth","Diglett","Dugtrio","Meowth",
+      "Persian","Psyduck","Golduck","Mankey","Primeape","Growlithe","Arcanine",
+      "Poliwag","Poliwhirl","Poliwrath","Abra","Kadabra","Alakazam","Machop",
+      "Machoke","Machamp","Bellsprout","Weepinbell","Victreebel","Tentacool",
+      "Tentacruel","Geodude","Graveler","Golem","Ponyta","Rapidash","Slowpoke",
+      "Slowbro","Magnemite","Magneton","Farfetch'd","Doduo","Dodrio","Seel",
+      "Dewgong","Grimer","Muk","Shellder","Cloyster","Gastly","Haunter",
+      "Gengar","Onix","Drowzee","Hypno","Krabby","Kingler","Voltorb",
+      "Electrode","Exeggcute","Exeggutor","Cubone","Marowak","Hitmonlee",
+      "Hitmonchan","Lickitung","Koffing","Weezing","Rhyhorn","Rhydon",
+      "Chansey","Tangela","Kangaskhan","Horsea","Seadra","Goldeen","Seaking",
+      "Staryu","Starmie","Mr. Mime","Scyther","Jynx","Electabuzz","Magmar",
+      "Pinsir","Tauros","Magikarp","Gyarados","Lapras","Ditto","Eevee",
+      "Vaporeon","Jolteon","Flareon","Porygon","Omanyte","Omastar","Kabuto",
+      "Kabutops","Aerodactyl","Snorlax","Articuno","Zapdos","Moltres",
+      "Dratini","Dragonair","Dragonite","Mewtwo","Mew"
+  ].freeze
+end

--- a/spec/forms/pokemons/create_pokemon_form_spec.rb
+++ b/spec/forms/pokemons/create_pokemon_form_spec.rb
@@ -4,6 +4,17 @@ RSpec.describe Pokemons::CreatePokemonForm, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:kind) }
+
+    it 'is one of the original 150 pokemon' do
+      params = { name: "Pingu", kind: "Fire" }
+      create_pokemon_form = Pokemons::CreatePokemonForm.new(params)
+
+      create_pokemon_form.save
+      
+      expect(
+        create_pokemon_form.errors[:name]
+      ).to eq(["must be one of the original 150 pokemon"])
+    end
   end
 
   describe '#save' do

--- a/spec/models/original_pokemon_spec.rb
+++ b/spec/models/original_pokemon_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe OriginalPokemon do
+  describe '::NAMES' do
+    it 'returns the array of pokemon names' do
+      stub_const("OriginalPokemon::NAMES", ["Charizard", "Mew"])
+      expect(OriginalPokemon::NAMES).to eq(["Charizard", "Mew"])
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures that when a User creates a pokemon by typing in their name, they can only create a pokemon that was part of the original 150.

In order to achieve this the codebase needs to know about the original 150. I have encapsulated this data into a PORO, that I will then be able to use in the future for other validations such as making sure when a pokemon evolves it will evolve into the correct pokemon.